### PR TITLE
Socks4-5 authentication in puppeteer

### DIFF
--- a/RuriLib/RuriLib.csproj
+++ b/RuriLib/RuriLib.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Scrypt.NET" Version="1.3.0" />
     <PackageReference Include="System.CodeDom" Version="5.0.0" />
     <PackageReference Include="websocketsharp.core" Version="1.0.0" />
+    <PackageReference Include="Yove.Proxy" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Support for socks proxy authentication in puppeteer using [TheSuunny/Yove.Proxy](https://github.com/TheSuunny/Yove.Proxy). Inside, it runs a local http proxy and redirects traffic to the socks proxy. A simple but working trick for solving #68 :)