### PR TITLE
Performance Improvments

### DIFF
--- a/RuriLib.Http/HttpResponseBuilder.cs
+++ b/RuriLib.Http/HttpResponseBuilder.cs
@@ -197,7 +197,7 @@ namespace RuriLib.Http
 
             var headerName = Encoding.UTF8.GetString(header.Slice(0, separatorPos));
             var headerValuespan = header.Slice(separatorPos + 1); // skip ':'
-            var headerValue = headerValuespan[0] == (byte)' ' ? Encoding.UTF8.GetString(headerValuespan.Slice(1)) : Encoding.UTF8.GetString(headerValuespan); // trim the wight space
+            var headerValue = headerValuespan[0] == (byte)' ' ? Encoding.UTF8.GetString(headerValuespan.Slice(1)) : Encoding.UTF8.GetString(headerValuespan); // trim the white space
 
             // If the header is Set-Cookie, add the cookie
             if (headerName.Equals("Set-Cookie", StringComparison.OrdinalIgnoreCase) ||


### PR DESCRIPTION
1- changed GetProxy Method In ProxyPool.cs to use a for loop instead of Linq as this is a hot Path and linq is slow
2- commited to use Span in Responce Header Parsing to increase performance and decrease allocated memory from strings.

These 2 changes will lead to good CPM improvement:
<a href='https://postimg.cc/YG6KPBhV' target='_blank'><img src='https://i.postimg.cc/YG6KPBhV/OB2CPM.png' border='0' alt='OB2CPM'/></a>
I was getting 900 - 1.2 k cpm on that Job.
now 3.5 k .