### PR TITLE
Memory Leak Fix - CPM Optimization

### DIFF
--- a/RuriLib.Parallelization/TaskBasedParallelizer.cs
+++ b/RuriLib.Parallelization/TaskBasedParallelizer.cs
@@ -78,6 +78,10 @@ namespace RuriLib.Parallelization
             Status = ParallelizerStatus.Stopping;
             hardCTS.Cancel();
             softCTS.Cancel();
+
+            hardCTS.Dispose();
+            softCTS.Dispose();
+            semaphore.Dispose();
         }
 
         /// <inheritdoc/>

--- a/RuriLib.Proxies/Clients/HttpProxyClient.cs
+++ b/RuriLib.Proxies/Clients/HttpProxyClient.cs
@@ -91,7 +91,7 @@ namespace RuriLib.Proxies.Clients
             {
                 return string.Empty;
             }
-                
+
             var data = Convert.ToBase64String(Encoding.UTF8.GetBytes(
                 $"{Settings.Credentials.UserName}:{Settings.Credentials.Password}"));
 
@@ -103,7 +103,7 @@ namespace RuriLib.Proxies.Clients
             var buffer = new byte[50];
             var responseBuilder = new StringBuilder();
 
-            var waitCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(nStream.ReadTimeout));
+            using var waitCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(nStream.ReadTimeout));
 
             while (!nStream.DataAvailable)
             {
@@ -116,7 +116,6 @@ namespace RuriLib.Proxies.Clients
 
                 await Task.Delay(100, cancellationToken).ConfigureAwait(false);
             }
-
             do
             {
                 var bytesRead = await nStream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);

--- a/RuriLib.Proxies/ProxyClient.cs
+++ b/RuriLib.Proxies/ProxyClient.cs
@@ -52,9 +52,10 @@ namespace RuriLib.Proxies
             // Try to connect to the proxy (or directly to the server in the NoProxy case)
             try
             {
-                var timeoutCts = new CancellationTokenSource(Settings.ConnectTimeout);
-                var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
+                using var timeoutCts = new CancellationTokenSource(Settings.ConnectTimeout);
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
                 await client.ConnectAsync(host, port, linkedCts.Token).ConfigureAwait(false);
+              
             }
             catch (Exception ex)
             {

--- a/RuriLib/Blocks/Requests/Http/Methods.cs
+++ b/RuriLib/Blocks/Requests/Http/Methods.cs
@@ -65,13 +65,14 @@ namespace RuriLib.Blocks.Requests.Http
             }
 
             data.Logger.LogHeader();
-            
+
             try
             {
                 Activity.Current = null;
-                var timeoutCts = new CancellationTokenSource(options.TimeoutMilliseconds);
-                var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(data.CancellationToken, timeoutCts.Token);
+                using var timeoutCts = new CancellationTokenSource(options.TimeoutMilliseconds);
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(data.CancellationToken, timeoutCts.Token);
                 using var response = await client.SendAsync(request, linkedCts.Token);
+
                 LogHttpRequestData(data, client);
                 await LogHttpResponseData(data, response, request, options);
             }
@@ -115,9 +116,10 @@ namespace RuriLib.Blocks.Requests.Http
             try
             {
                 Activity.Current = null;
-                var timeoutCts = new CancellationTokenSource(options.TimeoutMilliseconds);
-                var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(data.CancellationToken, timeoutCts.Token);
+                using var timeoutCts = new CancellationTokenSource(options.TimeoutMilliseconds);
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(data.CancellationToken, timeoutCts.Token);
                 using var response = await client.SendAsync(request, linkedCts.Token);
+
                 LogHttpRequestData(data, client);
                 await LogHttpResponseData(data, response, request, options);
             }
@@ -158,13 +160,14 @@ namespace RuriLib.Blocks.Requests.Http
                 Encoding.UTF8.GetBytes($"{options.Username}:{options.Password}")));
 
             data.Logger.LogHeader();
-            
+
             try
             {
                 Activity.Current = null;
-                var timeoutCts = new CancellationTokenSource(options.TimeoutMilliseconds);
-                var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(data.CancellationToken, timeoutCts.Token);
+                using var timeoutCts = new CancellationTokenSource(options.TimeoutMilliseconds);
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(data.CancellationToken, timeoutCts.Token);
                 using var response = await client.SendAsync(request, linkedCts.Token);
+               
                 LogHttpRequestData(data, client);
                 await LogHttpResponseData(data, response, request, options);
             }
@@ -244,9 +247,10 @@ namespace RuriLib.Blocks.Requests.Http
             try
             {
                 Activity.Current = null;
-                var timeoutCts = new CancellationTokenSource(options.TimeoutMilliseconds);
-                var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(data.CancellationToken, timeoutCts.Token);
+                using var timeoutCts = new CancellationTokenSource(options.TimeoutMilliseconds);
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(data.CancellationToken, timeoutCts.Token);
                 using var response = await client.SendAsync(request, linkedCts.Token);
+              
                 LogHttpRequestData(data, client);
                 await LogHttpResponseData(data, response, request, options);
             }
@@ -285,7 +289,7 @@ namespace RuriLib.Blocks.Requests.Http
 
             // Log the cookie header
             var cookies = data.COOKIES.Select(c => $"{c.Key}={c.Value}");
-            
+
             if (cookies.Any())
                 writer.WriteLine($"Cookie: {string.Join("; ", cookies)}");
 
@@ -365,7 +369,7 @@ namespace RuriLib.Blocks.Requests.Http
                         break;
                 }
             }
-            
+
             writer.WriteLine(boundary);
 
             return writer.ToString();
@@ -430,7 +434,7 @@ namespace RuriLib.Blocks.Requests.Http
             {
                 data.SOURCE = Encoding.UTF8.GetString(data.RAWSOURCE);
             }
-            
+
             data.Logger.Log("Received Payload:", LogColors.ForestGreen);
             data.Logger.Log(data.SOURCE, LogColors.GreenYellow, true);
         }
@@ -456,7 +460,7 @@ namespace RuriLib.Blocks.Requests.Http
             var fileContent = new StreamContent(stream);
             fileContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
             {
-                Name = $"\"{fieldName}\"",  
+                Name = $"\"{fieldName}\"",
                 FileName = $"\"{fileName}\""
             }; // the extra quotes are key here
             fileContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);

--- a/RuriLib/Models/Jobs/ProxyCheckJob.cs
+++ b/RuriLib/Models/Jobs/ProxyCheckJob.cs
@@ -74,10 +74,10 @@ namespace RuriLib.Models.Jobs
             try
             {
                 // Use 2 cancellation tokens since we need to control the proxy connect timeout as well
-                var cts = new CancellationTokenSource();
+                using var cts = new CancellationTokenSource();
                 cts.CancelAfter(input.Timeout);
 
-                var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, token);
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, token);
 
                 var sw = new Stopwatch();
                 sw.Start();


### PR DESCRIPTION
I noticed that CancellationTokenSource is being leaked by OB and it was causing massive memory consumption as it is never GC collected .

made small changes to CPM calculation to use int directly instead of datetime . 

i have a note regarding SslStream : 
 -  TLS 1.3 does not work on windows machines, this due to framework limitations not the code.
 - Allowed CipherSuites can only be used on linux and mac only. (this is also a windows issue not OB).
 
Just wanted to make you aware of that if any issues come up.