### PR TITLE
Throw a more useful exception on websocket disconnect

### DIFF
--- a/RuriLib/Blocks/Requests/WebSocket/Methods.cs
+++ b/RuriLib/Blocks/Requests/WebSocket/Methods.cs
@@ -63,6 +63,12 @@ namespace RuriLib.Blocks.Requests.WebSocket
                     wsMessages.Add(msg.Text);
                 }
             });
+            
+            ws.DisconnectionHappened.Subscribe(msg =>
+            {   
+                if (msg.Exception != null)
+                    throw new Exception(msg.Exception.ToString());
+            });
 
             // Connect
             await ws.Start();


### PR DESCRIPTION
Subcribing to the disconnect message and throwing the exception that caused the disconnect. This provides much more useful info  than just "Failed to connect to the websocket".