### PR TITLE
#394: Add multiline option for regex

### DIFF
--- a/OpenBullet2/Shared/ParseBlockSettingsViewer.razor
+++ b/OpenBullet2/Shared/ParseBlockSettingsViewer.razor
@@ -62,6 +62,7 @@
         case ParseMode.Regex:
             <BlockInputField BlockSetting="@Block.Settings["pattern"]" />
             <BlockInputField BlockSetting="@Block.Settings["outputFormat"]" />
+            <BlockInputField BlockSetting="@Block.Settings["multiLine"]" />
             break;
     }
 </EditForm>

--- a/RuriLib/Blocks/Parsing/Methods.cs
+++ b/RuriLib/Blocks/Parsing/Methods.cs
@@ -4,6 +4,7 @@ using RuriLib.Logging;
 using RuriLib.Models.Bots;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace RuriLib.Blocks.Parsing
 {
@@ -112,9 +113,9 @@ namespace RuriLib.Blocks.Parsing
 
         #region REGEX
         public static List<string> MatchRegexGroupsRecursive(BotData data, string input,
-            string pattern, string outputFormat, string prefix = "", string suffix = "")
+            string pattern, string outputFormat, bool multiLine, string prefix = "", string suffix = "")
         {
-            var parsed = RegexParser.MatchGroupsToString(input, pattern, outputFormat)
+            var parsed = RegexParser.MatchGroupsToString(input, pattern, outputFormat, multiLine ? RegexOptions.Multiline : RegexOptions.None)
                 .Select(p => prefix + p + suffix).ToList();
 
             data.Logger.LogHeader();
@@ -124,9 +125,9 @@ namespace RuriLib.Blocks.Parsing
         }
 
         public static string MatchRegexGroups(BotData data, string input, string pattern, string outputFormat,
-            string prefix = "", string suffix = "")
+            bool multiLine, string prefix = "", string suffix = "")
         {
-            var parsed = RegexParser.MatchGroupsToString(input, pattern, outputFormat).FirstOrDefault() ?? string.Empty;
+            var parsed = RegexParser.MatchGroupsToString(input, pattern, outputFormat, multiLine ? RegexOptions.Multiline : RegexOptions.None).FirstOrDefault() ?? string.Empty;
             parsed = prefix + parsed + suffix;
 
             data.Logger.LogHeader();

--- a/RuriLib/Functions/Parsing/RegexParser.cs
+++ b/RuriLib/Functions/Parsing/RegexParser.cs
@@ -18,7 +18,7 @@ namespace RuriLib.Functions.Parsing
         /// [1] with the first group etc.</param>
         /// <param name="options">The Regex Options to use</param>
         public static IEnumerable<string> MatchGroupsToString
-            (string input, string pattern, string outputFormat, RegexOptions? options = null)
+            (string input, string pattern, string outputFormat, RegexOptions options = RegexOptions.None)
         {
             if (input == null)
                 throw new ArgumentNullException(nameof(input));
@@ -29,7 +29,7 @@ namespace RuriLib.Functions.Parsing
             if (outputFormat == null)
                 throw new ArgumentNullException(nameof(outputFormat));
 
-            return Regex.Matches(input, pattern, options ?? new RegexOptions())
+            return Regex.Matches(input.Replace("\r\n", "\n"), pattern, options)
                 .Where(m => m.Success)
                 .Select(m => m.Groups.ToString(outputFormat));
         }

--- a/RuriLib/Functions/Parsing/RegexParser.cs
+++ b/RuriLib/Functions/Parsing/RegexParser.cs
@@ -29,7 +29,10 @@ namespace RuriLib.Functions.Parsing
             if (outputFormat == null)
                 throw new ArgumentNullException(nameof(outputFormat));
 
-            return Regex.Matches(input.Replace("\r\n", "\n"), pattern, options)
+            // Replacing \r\n with \n if multiline enabled
+            input = options.HasFlag(RegexOptions.Multiline) ? input.Replace("\r\n", "\n") : input;
+
+            return Regex.Matches(input, pattern, options)
                 .Where(m => m.Success)
                 .Select(m => m.Groups.ToString(outputFormat));
         }

--- a/RuriLib/Models/Blocks/Custom/ParseBlockDescriptor.cs
+++ b/RuriLib/Models/Blocks/Custom/ParseBlockDescriptor.cs
@@ -44,7 +44,8 @@ namespace RuriLib.Models.Blocks.Custom
 
                 // REGEX
                 { "pattern", new StringParameter("pattern") },
-                { "outputFormat", new StringParameter("outputFormat") }
+                { "outputFormat", new StringParameter("outputFormat") },
+                { "multiLine", new BoolParameter("multiLine", false) }
             };
         }
     }

--- a/RuriLib/Models/Blocks/Custom/ParseBlockInstance.cs
+++ b/RuriLib/Models/Blocks/Custom/ParseBlockInstance.cs
@@ -197,6 +197,7 @@ namespace RuriLib.Models.Blocks.Custom
                 case ParseMode.Regex:
                     writer.Write(CSharpWriter.FromSetting(Settings["pattern"]) + ", ");
                     writer.Write(CSharpWriter.FromSetting(Settings["outputFormat"]) + ", ");
+                    writer.Write(CSharpWriter.FromSetting(Settings["multiLine"]) + ", ");
                     break;
             }
 

--- a/RuriLib/Models/Blocks/Custom/ParseBlockInstance.cs
+++ b/RuriLib/Models/Blocks/Custom/ParseBlockInstance.cs
@@ -197,7 +197,7 @@ namespace RuriLib.Models.Blocks.Custom
                 case ParseMode.Regex:
                     writer.Write(CSharpWriter.FromSetting(Settings["pattern"]) + ", ");
                     writer.Write(CSharpWriter.FromSetting(Settings["outputFormat"]) + ", ");
-                    writer.Write(CSharpWriter.FromSetting(Settings["multiLine"]) + ", ");
+                    writer.Write("multiLine: " + CSharpWriter.FromSetting(Settings["multiLine"]) + ", ");
                     break;
             }
 


### PR DESCRIPTION
This PR adds multline option support for regex parsing (issue #394).
The reason why I replace `\r\n` with `\n` is, because multiline regexes in C# don't match `\r\n` as the end of the line, so if we have a string `123\r\naaa\r\n1a2\r\n` and regex `^[a-z]{3}$`, it wont match `aaa`.
If you would like the replacement to happen somewhere else, let me know.
