### PR TITLE
Add Random GUID function block and move General Purpose functions to Miscelaneous group

### DIFF
--- a/RuriLib/Blocks/Functions/Miscellanous/Methods.cs
+++ b/RuriLib/Blocks/Functions/Miscellanous/Methods.cs
@@ -1,10 +1,11 @@
 ﻿using RuriLib.Attributes;
 using RuriLib.Models.Bots;
 using RuriLib.Providers.UserAgents;
+using System;
 
-namespace RuriLib.Blocks.Functions
+namespace RuriLib.Blocks.Functions.Miscellanous
 {
-    [BlockCategory("Functions", "General purpose functions", "#9acd32")]
+    [BlockCategory("Miscellanous", "General purpose functions", "#9acd32")]
     public static class Methods
     {
         [Block("Generates a random User Agent using the builtin provider or a custom list")]
@@ -25,6 +26,19 @@ namespace RuriLib.Blocks.Functions
 
             data.Logger.Log(ua);
             return ua;
+        }
+
+        [Block("Generates a random GUID using the builtin provider",
+            extraInfo = "Full list of formats here: https://learn.microsoft.com/en-us/dotnet/api/system.guid.tostring under the 'Remarks' section")]
+        public static string RandomGuid(BotData data, string format = "D")
+        {
+            data.Logger.LogHeader();
+            data.Logger.Log("Getting random GUID from the builtin provider");
+            
+            var guid = Guid.NewGuid().ToString(format);
+            data.Logger.Log(guid);
+
+            return guid;
         }
     }
 }


### PR DESCRIPTION
This PR adds a new function block called "Random GUID" which generates a random GUID using the built-in provider. It also allows to specify a format of the Guid. This can be useful for various situations like generating unique identifiers for objects, data, etc.

Additionally, it moves the "Random User Agent" block and the entire "General Purpose functions" group to a new group called "Miscellaneous".
This change makes it easier to find and use these functions and improves the organization of the blocks in the library.

Closes #840