### PR TITLE
Add a null check for ConfigDebugger creation

### DIFF
--- a/OpenBullet2/Shared/Debugger.razor.cs
+++ b/OpenBullet2/Shared/Debugger.razor.cs
@@ -40,13 +40,15 @@ namespace OpenBullet2.Shared
         {
             try
             {
-                debugger = new ConfigDebugger(Config, options, logger)
-                {
-                    PluginRepo = PluginRepo,
-                    RandomUAProvider = RandomUAProvider,
-                    RNGProvider = RNGProvider,
-                    RuriLibSettings = RuriLibSettings
-                };
+                if (debugger == null) {
+                    debugger = new ConfigDebugger(Config, options, logger)
+                    {
+                        PluginRepo = PluginRepo,
+                        RandomUAProvider = RandomUAProvider,
+                        RNGProvider = RNGProvider,
+                        RuriLibSettings = RuriLibSettings
+                    };
+                }
 
                 debugger.NewLogEntry += OnNewEntry;
                 debugger.StatusChanged += UpdateState;


### PR DESCRIPTION
ConfigDebugger expects to be reused, so recreating it on every run leads to a process leak (`lastSeleniumBrowser` and `lastPuppeteerBrowser` never get quit)

Something similar needs to be done for the [native client](https://github.com/openbullet/OpenBullet2/blob/90c6614f6eb9c90be58dbe8d4ad9b19ea2569aa5/OpenBullet2.Native/ViewModels/DebuggerViewModel.cs#L201-L207), but i can't do that since i'm a linux user

Consider adding `--init` to the docker run command in the guide (https://github.com/puppeteer/puppeteer/issues/1825#issuecomment-792817748)

Possibly closes #213

I've also noticed memory usage increases by ~200MB when running with debug or multi run, no idea why. Seems unrelated to selenium/puppeteer and it happens with the release version too.