### PR TITLE
Update SSH.NET to 2023.0.0

### DIFF
--- a/RuriLib/RuriLib.csproj
+++ b/RuriLib/RuriLib.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Scrypt.NET" Version="1.3.0" />
     <PackageReference Include="Selenium.Support" Version="4.0.1" />
     <PackageReference Include="Selenium.WebDriver" Version="4.0.1" />
-    <PackageReference Include="SSH.NET" Version="2020.0.1" />
+    <PackageReference Include="SSH.NET" Version="2023.0.0" />
     <PackageReference Include="Svg" Version="3.2.3" />
     <PackageReference Include="System.CodeDom" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />


### PR DESCRIPTION
Update SSH.NET to the latest version https://www.nuget.org/packages/SSH.NET/2023.0.0

## New features:
* Support for .NET 6, 7, and .NET Standard 2.0/2.1
* Support for RSA-SHA256/512 signature algorithms
* Support for parsing OpenSSH keys with ECDSA 256/384/521 and RSA
* Support for SHA256 and MD5 fingerprints for host key validation
* Added async support to SftpClient and SftpFileStream
* Added ISftpFile interface to SftpFile
* Removed support for old target frameworks
* Improved performance and stability
* Added the ability to set the last write and access time for Sftp files