### PR TITLE
bug fix

### DIFF
--- a/OpenBullet2.Native/Views/Pages/Wordlists.xaml
+++ b/OpenBullet2.Native/Views/Pages/Wordlists.xaml
@@ -40,13 +40,7 @@
                     <TextBlock VerticalAlignment="Center" Margin="5 0">Delete Not Found</TextBlock>
                 </StackPanel>
             </Button>
-            <TextBox x:Name="filterTextbox" Text="{Binding SearchString}" Margin="10 5 5 5" Width="150" KeyDown="UpdateSearch"/>
-            <Button Style="{StaticResource StyledButton}" x:Name="searchButton" Click="Search" Margin="0 5 5 5" >
-                <StackPanel Orientation="Horizontal">
-                    <iconPacks:PackIconMaterialDesign Kind="Search" />
-                    <TextBlock VerticalAlignment="Center" Margin="5 0">Search</TextBlock>
-                </StackPanel>
-            </Button>
+            <TextBox x:Name="filterTextbox" Text="{Binding SearchString, UpdateSourceTrigger=PropertyChanged}" Margin="10 5 5 5" Width="150" KeyDown="UpdateSearch"/>
         </StackPanel>
 
         <ListView x:Name="wordlistListView" Grid.Row="1" Foreground="{DynamicResource ForegroundMain}" Background="Transparent" ItemsSource="{Binding Path=WordlistsCollection}" SelectionMode="Extended" BorderThickness="1" AllowDrop="True" Drop="HandleDrop">

--- a/OpenBullet2.Native/Views/Pages/Wordlists.xaml.cs
+++ b/OpenBullet2.Native/Views/Pages/Wordlists.xaml.cs
@@ -73,7 +73,6 @@ namespace OpenBullet2.Native.Views.Pages
             }
         }
 
-        private void Search(object sender, RoutedEventArgs e) => vm.SearchString = filterTextbox.Text;
 
         public async void AddWordlist(WordlistEntity wordlist)
         {
@@ -135,7 +134,7 @@ namespace OpenBullet2.Native.Views.Pages
                         var entity = new WordlistEntity
                         {
                             Name = Path.GetFileNameWithoutExtension(file),
-                            FileName = path,
+                            FileName = path.Replace("\\", "/"),
                             Type = env.RecognizeWordlistType(firstLine),
                             Purpose = string.Empty,
                             Total = File.ReadLines(path).Count()

--- a/OpenBullet2.Native/Views/Pages/Wordlists.xaml.cs
+++ b/OpenBullet2.Native/Views/Pages/Wordlists.xaml.cs
@@ -135,7 +135,7 @@ namespace OpenBullet2.Native.Views.Pages
                         var entity = new WordlistEntity
                         {
                             Name = Path.GetFileNameWithoutExtension(file),
-                            FileName = path,
+                            FileName = path.Replace("\\", "/"),
                             Type = env.RecognizeWordlistType(firstLine),
                             Purpose = string.Empty,
                             Total = File.ReadLines(path).Count()


### PR DESCRIPTION
1.
OpenBullet2.Native Worldlists.xaml Text="{Binding SearchString}"  Need Text="{Binding SearchString, UpdateSourceTrigger=PropertyChanged}" and delete Click="Search"(Delete method Search)

2. OpenBullet2.Native Worldlists.xaml.cs position 137 FileName = path,  Need FileName = path.Replace("\\", "/"),