### PR TITLE
Add elliptic curve support for JWT signature

### DIFF
--- a/RuriLib/Functions/Crypto/Crypto.cs
+++ b/RuriLib/Functions/Crypto/Crypto.cs
@@ -628,6 +628,7 @@ namespace RuriLib.Functions.Crypto
         {
             IJwtAlgorithm algorithm = null;
             RSA rsa = null;
+            ECDsa ecdsa = null;
             try
             {
                 switch (algorithmName)
@@ -671,6 +672,21 @@ namespace RuriLib.Functions.Crypto
                         rsa.ImportFromPem(secret.ToCharArray());
                         algorithm = new RS4096Algorithm(rsa, rsa);
                         break;
+                    case JwtAlgorithmName.ES256:
+                        ecdsa = ECDsa.Create();
+                        ecdsa.ImportFromPem(secret.ToCharArray());
+                        algorithm = new ES256Algorithm(ecdsa, ecdsa);
+                        break;
+                    case JwtAlgorithmName.ES384:
+                        ecdsa = ECDsa.Create();
+                        ecdsa.ImportFromPem(secret.ToCharArray());
+                        algorithm = new ES384Algorithm(ecdsa, ecdsa);
+                        break;
+                    case JwtAlgorithmName.ES512:
+                        ecdsa = ECDsa.Create();
+                        ecdsa.ImportFromPem(secret.ToCharArray());
+                        algorithm = new ES512Algorithm(ecdsa, ecdsa);
+                        break;
                     default:
                         throw new NotSupportedException("This algorithm is not supported at the moment");
                 }
@@ -684,6 +700,7 @@ namespace RuriLib.Functions.Crypto
             finally
             {
                 rsa?.Dispose();
+                ecdsa?.Dispose();
             }
         }
         #endregion


### PR DESCRIPTION
# Description

This pull request implements EC signing support for JWT encoding. The JwtEncode method has been modified to include support for ES256, ES384 and ES512 algorithms.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

 - [X] Tests have been carried out to verify the encoding functionality for each ECDSA algorithm.
 
 Example in LoliCode :
 
```
string privateKey = @"-----BEGIN EC PRIVATE KEY-----
MHQCAQEEIEYgBlyQVsH7SpHUH7x4RErcckhu7ary/JjhP72Nk19EoAcGBSuBBAAK
oUQDQgAE1MtHIxlGP5TARqBccrddNm1FnYH1Fp+onETz5KbXPSeG5FGwKMUXGfAm
SZJq2gENULFewwymt+9bTXkjBZhh8A==
-----END EC PRIVATE KEY-----";

BLOCK:JwtEncode
  algorithm = ES256
  secret = @privateKey
  payload = "{\"open\":\"bullet\"}"
  => VAR @jwtEncodeOutput
ENDBLOCK
```
