### PR TITLE
Fixed port binding on docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         # You can set a windows dir like 'C:/OB2/UserData/:/app/UserData/' but it will always be 'local dir:docker dir'
             - './UserData:/app/UserData/'
         ports:
-            - '8069:5000'
+            - '5000:5000'
 
 volumes:
     UserData:


### PR DESCRIPTION
# Description

The ports binding on the docker compose file hasn't changed. However since port 5000 is exposed on the Dockerfile and the port is implicitly forced with dotnet run argument "--urls" we need to do the same with the docker compose file.