### PR TITLE
New Logoff function for Multi run job

### DIFF
--- a/OpenBullet2.Core/Models/Jobs/MultiRunJobOptions.cs
+++ b/OpenBullet2.Core/Models/Jobs/MultiRunJobOptions.cs
@@ -1,4 +1,4 @@
-﻿using OpenBullet2.Core.Models.Data;
+using OpenBullet2.Core.Models.Data;
 using OpenBullet2.Core.Models.Hits;
 using OpenBullet2.Core.Models.Proxies;
 using RuriLib.Models.Jobs;
@@ -29,6 +29,11 @@ public class MultiRunJobOptions : JobOptions
 
     /// <summary>
     /// The proxy mode.
+    /// </summary>
+    public bool Logoff { get; set; } = false;
+
+    /// <summary>
+    /// disable log
     /// </summary>
     public JobProxyMode ProxyMode { get; set; } = JobProxyMode.Default;
 

--- a/OpenBullet2.Core/Services/JobFactoryService.cs
+++ b/OpenBullet2.Core/Services/JobFactoryService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OpenBullet2.Core.Models.Hits;
 using OpenBullet2.Core.Models.Jobs;
@@ -107,6 +107,7 @@ public class JobFactoryService
             BotLimit = BotLimit,
             CurrentBotDatas = new BotData[BotLimit],
             Skip = options.Skip,
+            Logoff = options.Logoff,
             HitOutputs = options.HitOutputs.Select(o => hitOutputsFactory.FromOptions(o)).ToList(),
             ProxySources = options.ProxySources.Select(s => proxySourceFactory.FromOptions(s).Result).ToList(),
             Providers = new(_settingsService)

--- a/OpenBullet2.Native/Views/Dialogs/MultiRunJobOptionsDialog.xaml
+++ b/OpenBullet2.Native/Views/Dialogs/MultiRunJobOptionsDialog.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="OpenBullet2.Native.Views.Dialogs.MultiRunJobOptionsDialog"
+<Page x:Class="OpenBullet2.Native.Views.Dialogs.MultiRunJobOptionsDialog"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -117,6 +117,10 @@
                           Value="{Binding Skip, Mode=TwoWay}"
                           Width="100"/>
                         </StackPanel>
+                        <CheckBox
+                Margin="5 5 0 0"
+                Content="Disable writing logs"
+                IsChecked="{Binding Logoff}" />
                         <StackPanel Orientation="Horizontal" Margin="0 5 0 0">
                             <Label>Proxy mode</Label>
                             <ComboBox

--- a/OpenBullet2.Native/Views/Dialogs/MultiRunJobOptionsDialog.xaml.cs
+++ b/OpenBullet2.Native/Views/Dialogs/MultiRunJobOptionsDialog.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Win32;
 using OpenBullet2.Core.Entities;
 using OpenBullet2.Core.Models.Data;
@@ -300,6 +300,16 @@ namespace OpenBullet2.Native.Views.Dialogs
             set
             {
                 Options.Skip = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool Logoff
+        {
+            get => Options.Logoff;
+            set
+            {
+                Options.Logoff = value;
                 OnPropertyChanged();
             }
         }

--- a/RuriLib/Models/Jobs/MultiRunJob.cs
+++ b/RuriLib/Models/Jobs/MultiRunJob.cs
@@ -41,6 +41,7 @@ namespace RuriLib.Models.Jobs
         public int Bots { get; set; } = 1;
         public int BotLimit { get; init; } = 200;
         public int Skip { get; set; } = 0;
+        public bool Logoff { get; set; } = false;
         public Config Config { get; set; }
         public DataPool DataPool { get; set; }
         public List<ProxySource> ProxySources { get; set; } = new List<ProxySource>();
@@ -925,7 +926,7 @@ namespace RuriLib.Models.Jobs
         {
             var botData = details.Result.BotData;
 
-            if (IsHitStatus(botData.STATUS))
+            if (IsHitStatus(botData.STATUS)&&!Logoff)
             {
                 // Fire and forget
                 RegisterHit(details.Result).ConfigureAwait(false);


### PR DESCRIPTION
Configs that generated a very large amount of bot status data, such as hits and others, used a large amount of RAM unnecessarily. 

The logoff option allows you to disable bot data writing, while the number of hits and other statuses is displayed.

Hits and other bot statuses can be read by saving the data to a file when creating the config.

The difference in RAM consumption for me by openbullet is:

**without "logoff", 4 GB of RAM usage after a few hours** 

**With "logoff" function enabled, 600 mb of RAM usage after a few hours.**

optional: add logoff selection mode, no logs in multi run or no logs in multirun and in the database.


![obraz](https://github.com/user-attachments/assets/a45acbcd-f66b-4236-a51c-109e686117f1)

![obraz](https://github.com/user-attachments/assets/e8987324-0fe8-432c-b7a5-54b19f2da11c)
