### PR TITLE
fix: modernize Dockerfiles (fix broken builds, remove deprecated dependencies)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,13 @@ RUN cp /code/OpenBullet2.Web/dbip-country-lite.mmdb /build
 # --------
 # FRONTEND
 # --------
-FROM node:20.9.0 AS frontend
+FROM node:22-bookworm-slim AS frontend
 
 WORKDIR /code
 
 COPY openbullet2-web-client/package.json .
 COPY openbullet2-web-client/package-lock.json .
-RUN npm install
+RUN npm ci
 
 COPY openbullet2-web-client .
 RUN npm run build
@@ -50,20 +50,19 @@ COPY --from=backend /build/web .
 COPY --from=frontend /build ./wwwroot
 COPY OpenBullet2.Web/dbip-country-lite.mmdb .
 
-# Install dependencies
-RUN apt-get update -yq && apt-get install -y --no-install-recommends apt-utils
-RUN apt-get upgrade -yq && apt-get install -yq apt-utils curl git nano wget unzip python3 python3-pip
+# Install dependencies and Node.js in a single layer to reduce image size
+RUN apt-get update -yq \
+    && apt-get install -y --no-install-recommends \
+        apt-utils curl git nano wget unzip \
+        python3 \
+        nodejs npm \
+        chromium firefox-esr \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Setup nodejs
-RUN curl -sL https://deb.nodesource.com/setup_current.x | bash - && apt-get install -yq nodejs build-essential
-RUN echo "deb http://deb.debian.org/debian/ unstable main contrib non-free" >> /etc/apt/sources.list.d/debian.list
-
-# Install chromium and firefox for selenium and puppeteer
-RUN apt-get update -yq && apt-get install -y --no-install-recommends firefox chromium
-RUN pip3 install webdrivermanager || true
-RUN webdrivermanager firefox chrome --linkpath /usr/local/bin || true
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+# Note: Selenium 4.6+ includes Selenium Manager which automatically
+# downloads the correct browser drivers at runtime. No need for
+# the deprecated webdrivermanager pip package.
 
 EXPOSE 5000
 CMD ["dotnet", "./OpenBullet2.Web.dll", "--urls=http://*:5000"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -39,13 +39,13 @@ RUN cp /code/OpenBullet2.Web/dbip-country-lite.mmdb /build
 # --------
 # FRONTEND
 # --------
-FROM node:20.9.0 AS frontend
+FROM node:22-bookworm-slim AS frontend
 
 WORKDIR /code
 
 COPY openbullet2-web-client/package.json .
 COPY openbullet2-web-client/package-lock.json .
-RUN npm install
+RUN npm ci
 
 COPY openbullet2-web-client .
 RUN npm run build

--- a/Dockerfile.remote
+++ b/Dockerfile.remote
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0-bookworm-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install basic dependencies
+# Install dependencies, Node.js, and browsers in a single layer
 RUN apt-get update -yq \
     && apt-get install -y --no-install-recommends \
         apt-utils \
@@ -12,32 +12,15 @@ RUN apt-get update -yq \
         wget \
         unzip \
         python3 \
-        python3-pip \
-        gnupg \
-        lsb-release \
-        software-properties-common
+        nodejs npm \
+        chromium \
+        firefox-esr \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-# Setup Node.js (LTS Version)
-RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - \
-    && apt-get install -yq nodejs build-essential
-
-# Add Mozilla Team PPA for the latest Firefox
-RUN echo "deb http://ppa.launchpad.net/mozillateam/ppa/ubuntu focal main" | tee /etc/apt/sources.list.d/mozillateam-ppa.list \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A6DCF7707EBC211F \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9BDB3D89CE49EC21 \
-    && apt-get update -yq
-
-# Install the latest Firefox and Chromium
-RUN apt-get install -y --no-install-recommends \
-        firefox \
-        chromium
-
-# Install WebDriverManager
-RUN pip3 install webdrivermanager || true \
-    && webdrivermanager firefox chrome --linkpath /usr/local/bin || true
-
-# Clean up
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+# Note: Selenium 4.6+ includes Selenium Manager which automatically
+# downloads the correct browser drivers at runtime. No need for
+# the deprecated webdrivermanager pip package.
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
Modernizes all three Dockerfiles (`Dockerfile`, `Dockerfile.build`, `Dockerfile.remote`) by replacing deprecated/abandoned tools that cause build failures.

## Changes
- **Node.js** image updated from `20.9.0` to `22` (current LTS)
- **Removed deprecated NodeSource** `setup_current.x` / `setup_lts.x` scripts (NodeSource deprecated these setup scripts, breaking Docker builds)
- **Removed abandoned `webdrivermanager`** pip package (last release 2020) — Selenium 4.6+ includes built-in Selenium Manager that auto-downloads browser drivers
- **Removed unstable Debian repo** hack (`deb.debian.org/debian/ unstable`) that could cause unpredictable build breaks
- **Removed deprecated `apt-key`** usage in `Dockerfile.remote`
- **Consolidated `RUN` layers** to reduce final image size
- **`npm install` → `npm ci`** for reproducible, faster builds
- **`firefox` → `firefox-esr`** (available directly from Debian stable repos, no PPA needed)

## Why
Several tools used in the Dockerfiles have been deprecated or abandoned, causing Docker builds to fail:
1. NodeSource removed their `setup_current.x` script
2. The `webdrivermanager` pip package hasn't been updated since 2020
3. Adding `unstable` Debian repos is fragile and can break at any time

These are all resolved by using packages available directly in Debian bookworm repos.