### PR TITLE
chore: update NuGet dependencies (security, stability, and build fixes)

### DIFF
--- a/OpenBullet2.Core/OpenBullet2.Core.csproj
+++ b/OpenBullet2.Core/OpenBullet2.Core.csproj
@@ -17,7 +17,10 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5"/>
+        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.12.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OpenBullet2.Core/OpenBullet2.Core.csproj
+++ b/OpenBullet2.Core/OpenBullet2.Core.csproj
@@ -7,13 +7,13 @@
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Core" Version="1.6.0"/>
         <PackageReference Include="MaxMind.GeoIP2" Version="5.2.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.6"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8"/>
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>

--- a/OpenBullet2.Native/OpenBullet2.Native.csproj
+++ b/OpenBullet2.Native/OpenBullet2.Native.csproj
@@ -106,14 +106,14 @@
         <PackageReference Include="MahApps.Metro.IconPacks" Version="4.8.0" />
         <PackageReference Include="MahApps.Metro.SimpleChildWindow" Version="2.2.1" />
         <PackageReference Include="Markdig" Version="0.37.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.6"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1"/>
         <PackageReference Include="nulastudio.NetBeauty" Version="2.1.4.5"/>
         <PackageReference Include="WpfAnimatedGif" Version="2.0.2"/>
     </ItemGroup>

--- a/OpenBullet2.Native/OpenBullet2.Native.csproj
+++ b/OpenBullet2.Native/OpenBullet2.Native.csproj
@@ -101,7 +101,10 @@
 
     <ItemGroup>
         <PackageReference Include="AvalonEdit" Version="6.3.0.90" />
-        <PackageReference Include="HtmlSanitizer" Version="8.1.866-beta" />
+        <PackageReference Include="HtmlSanitizer" Version="9.0.835" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.12.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
         <PackageReference Include="MahApps.Metro" Version="2.4.10" />
         <PackageReference Include="MahApps.Metro.IconPacks" Version="4.8.0" />
         <PackageReference Include="MahApps.Metro.SimpleChildWindow" Version="2.2.1" />

--- a/OpenBullet2.Native/OpenBullet2.Native.csproj
+++ b/OpenBullet2.Native/OpenBullet2.Native.csproj
@@ -105,6 +105,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.12.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
+        <PackageReference Include="AngleSharp" Version="1.4.0" />
         <PackageReference Include="MahApps.Metro" Version="2.4.10" />
         <PackageReference Include="MahApps.Metro.IconPacks" Version="4.8.0" />
         <PackageReference Include="MahApps.Metro.SimpleChildWindow" Version="2.2.1" />

--- a/OpenBullet2.Web/OpenBullet2.Web.csproj
+++ b/OpenBullet2.Web/OpenBullet2.Web.csproj
@@ -45,15 +45,15 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="13.0.1" />
-        <PackageReference Include="FluentValidation" Version="11.9.2" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
+        <PackageReference Include="FluentValidation" Version="11.11.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.11.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8"/>
         <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.11" />
         <PackageReference Include="nulastudio.NetBeauty" Version="2.1.4.5"/>
-        <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+        <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
         <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
         <PackageReference Include="SonarAnalyzer.CSharp" Version="9.27.0.93347">
             <PrivateAssets>all</PrivateAssets>

--- a/RuriLib/Blocks/Selenium/Browser/Methods.cs
+++ b/RuriLib/Blocks/Selenium/Browser/Methods.cs
@@ -96,7 +96,7 @@ namespace RuriLib.Blocks.Selenium.Browser
                     fireservice.SuppressInitialDiagnosticInformation = true;
                     fireservice.HideCommandPromptWindow = true;
                     fireop.AddArgument("--log-level=3");
-                    fireop.BrowserExecutableLocation = provider.FirefoxBinaryLocation;
+                    fireop.BinaryLocation = provider.FirefoxBinaryLocation;
 
                     if (Utils.IsDocker())
                     {

--- a/RuriLib/Legacy/Blocks/SBlockBrowserAction.cs
+++ b/RuriLib/Legacy/Blocks/SBlockBrowserAction.cs
@@ -404,7 +404,7 @@ namespace RuriLib.Legacy.Blocks
                     fireservice.SuppressInitialDiagnosticInformation = true;
                     fireservice.HideCommandPromptWindow = true;
                     fireop.AddArgument("--log-level=3");
-                    fireop.BrowserExecutableLocation = provider.FirefoxBinaryLocation;
+                    fireop.BinaryLocation = provider.FirefoxBinaryLocation;
 
                     if (Helpers.Utils.IsDocker())
                     {

--- a/RuriLib/RuriLib.csproj
+++ b/RuriLib/RuriLib.csproj
@@ -7,28 +7,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="1.1.2" />
+    <PackageReference Include="AngleSharp" Version="1.4.0" />
 	<PackageReference Include="BCrypt.Net-Core" Version="1.6.0" />
     <PackageReference Include="CaptchaSharp" Version="2.1.0" />
     <PackageReference Include="DeviceId" Version="5.2.0" />
-    <PackageReference Include="FluentFTP" Version="50.0.1" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
+    <PackageReference Include="FluentFTP" Version="53.0.2" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="IronPython" Version="2.7.11" />
     <PackageReference Include="IronPython.StdLib" Version="2.7.11" />
     <PackageReference Include="Jering.Javascript.NodeJS" Version="7.0.0" />
     <PackageReference Include="Jint" Version="3.1.2" />
     <PackageReference Include="JWT" Version="10.1.1" />
-    <PackageReference Include="MailKit" Version="4.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.5.0" />
+    <PackageReference Include="MailKit" Version="4.15.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.12.0" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="PuppeteerExtraSharp" Version="2.0.0" />
     <PackageReference Include="PuppeteerSharp" Version="9.0.2" />
     <PackageReference Include="Scrypt.NET" Version="1.3.0" />
-    <PackageReference Include="Selenium.Support" Version="4.21.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
-    <PackageReference Include="SSH.NET" Version="2024.0.0" />
+    <PackageReference Include="Selenium.Support" Version="4.41.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.41.0" />
+    <PackageReference Include="SSH.NET" Version="2024.1.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />


### PR DESCRIPTION
## Summary
Updates 24 NuGet dependencies across the solution to improve security, performance, and stability. This PR also resolves specific build conflicts and patches known vulnerabilities.

## Changes
- **NuGet Updates**: Bumps major dependencies including:
  - `AngleSharp` (1.4.0)
  - `Selenium.WebDriver` (4.41.0)
  - `Microsoft.EntityFrameworkCore` (8.0.8)
  - `MailKit` (4.15.0)
  - `Serilog.AspNetCore` (10.0.0)
  - `FluentValidation` (11.11.0)
- **Security Patches**:
  - Updated `SixLabors.ImageSharp` to 3.1.6 (fixes High/Moderate vulnerabilities)
  - Updated `HtmlSanitizer` to 9.0.835 (fixes Moderate vulnerability)
- **Build & Conflict Resolution**:
  - Unified `Microsoft.CodeAnalysis` version to 4.12.0 across all projects to resolve version mismatches between RuriLib and EFCore.Design.
  - Added explicit `AngleSharp` reference to `OpenBullet2.Native` to resolve dependency conflicts.
- **Selenium 4.x Fix**:
  - Updated `RuriLib` Firefox options to use the new `BinaryLocation` property (replacing the renamed `BrowserExecutableLocation`).

## Verification
- Verified build succeeds using `.NET 10 SDK` targeting `.NET 8`.
- Ran `dotnet test`: 202/203 RuriLib tests passed.