### PR TITLE
Fix zstd decoding in System.Net handler

### DIFF
--- a/RuriLib.Http/Helpers/ContentEncodingHelper.cs
+++ b/RuriLib.Http/Helpers/ContentEncodingHelper.cs
@@ -5,7 +5,7 @@ using System.IO.Compression;
 
 namespace RuriLib.Http.Helpers;
 
-internal static class ContentEncodingHelper
+public static class ContentEncodingHelper
 {
     private static readonly HashSet<string> IgnoredEncodings = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -17,7 +17,7 @@ internal static class ContentEncodingHelper
         "false"
     };
 
-    internal static Stream GetDecodedStream(Stream stream, IEnumerable<string> headerValues)
+    public static Stream GetDecodedStream(Stream stream, IEnumerable<string> headerValues)
     {
         ArgumentNullException.ThrowIfNull(stream);
         ArgumentNullException.ThrowIfNull(headerValues);

--- a/RuriLib.Http/Properties/AssemblyInfo.cs
+++ b/RuriLib.Http/Properties/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("RuriLib.Http.Tests")]
+[assembly: InternalsVisibleTo("RuriLib")]

--- a/RuriLib.Http/Properties/AssemblyInfo.cs
+++ b/RuriLib.Http/Properties/AssemblyInfo.cs
@@ -1,4 +1,3 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("RuriLib.Http.Tests")]
-[assembly: InternalsVisibleTo("RuriLib")]

--- a/RuriLib/Functions/Http/HttpClientRequestHandler.cs
+++ b/RuriLib/Functions/Http/HttpClientRequestHandler.cs
@@ -3,6 +3,7 @@ using RuriLib.Functions.Conversion;
 using RuriLib.Functions.Files;
 using RuriLib.Functions.Http.Options;
 using RuriLib.Helpers;
+using RuriLib.Http.Helpers;
 using RuriLib.Logging;
 using RuriLib.Models.Blocks.Custom.HttpRequest.Multipart;
 using RuriLib.Models.Bots;
@@ -10,7 +11,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -570,24 +570,26 @@ internal class HttpClientRequestHandler : HttpRequestHandler
         data.Logger.Log("Received Cookies:", LogColors.MikadoYellow);
         data.Logger.Log(data.COOKIES.Select(h => $"{h.Key}: {h.Value}"), LogColors.Khaki);
 
-        // Decode brotli if still compressed
-        if (data.HEADERS.TryGetValue("Content-Encoding", out var value) && value.Contains("br"))
+        // Decode the response if still compressed
+        if (data.RAWSOURCE.Length > 0 && data.HEADERS.TryGetValue("Content-Encoding", out var value)
+            && !string.IsNullOrWhiteSpace(value))
         {
             try
             {
                 using var inputStream = new MemoryStream(data.RAWSOURCE);
                 using var outputStream = new MemoryStream();
-                await using var brotli = new BrotliStream(inputStream, CompressionMode.Decompress, false);
-                await brotli.CopyToAsync(outputStream);
+                using var decodedStream = ContentEncodingHelper.GetDecodedStream(inputStream, [value]);
+                decodedStream.CopyTo(outputStream);
                 data.RAWSOURCE = outputStream.ToArray();
             }
-            catch
+            catch (Exception ex)
             {
-                data.Logger.Log("[WARNING] Tried to decompress brotli but failed", LogColors.DarkOrange);
+                data.Logger.Log($"[WARNING] Tried to decompress {value} but failed: {ex.Message}",
+                    LogColors.DarkOrange);
             }
         }
 
-        // Unzip the GZipped content if still gzipped (after Content-Length calculation)
+        // Fallback for gzip bodies that still reach us compressed without a Content-Encoding header
         if (data.RAWSOURCE.Length > 1 && data.RAWSOURCE[0] == 0x1F && data.RAWSOURCE[1] == 0x8B)
         {
             try

--- a/RuriLib/Functions/Http/HttpRequestHandler.cs
+++ b/RuriLib/Functions/Http/HttpRequestHandler.cs
@@ -14,7 +14,7 @@ namespace RuriLib.Functions.Http;
 
 internal abstract class HttpRequestHandler
 {
-    protected static readonly string[] commaHeaders = ["Accept", "Accept-Encoding"];
+    protected static readonly string[] commaHeaders = ["Accept", "Accept-Encoding", "Content-Encoding"];
 
     public virtual Task HttpRequestStandard(BotData data, StandardHttpRequestOptions options)
         => throw new NotImplementedException();


### PR DESCRIPTION
## Description

Hi, this PR fixes zstd response decompression when using the System.Net HTTP library.

## Type of change

Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

Tested with a website returning `Content-Encoding: zstd` while using the `System.Net` HTTP library.
Before this change, the response body was returned as raw compressed bytes. After this change, the response is correctly decompressed and the HTML payload is readable.