### PR TITLE
fix: make disabled lolicode block colors more distinguishable

### DIFF
--- a/OpenBullet2.Native/ViewModels/ConfigStackerViewModel.cs
+++ b/OpenBullet2.Native/ViewModels/ConfigStackerViewModel.cs
@@ -291,6 +291,6 @@ public class BlockViewModel(BlockInstance block) : ViewModelBase
         }
     }
 
-    public string BackgroundColor => Disabled ? "#444" : Block.Descriptor.Category.BackgroundColor;
-    public string ForegroundColor => Disabled ? "#FFF" : Block.Descriptor.Category.ForegroundColor;
+    public string BackgroundColor => Disabled ? "#1A1A1A" : Block.Descriptor.Category.BackgroundColor;
+    public string ForegroundColor => Disabled ? "#777777" : Block.Descriptor.Category.ForegroundColor;
 }


### PR DESCRIPTION
Changed disabled block colors from #444/#FFF to #1A1A1A/#777 so disabled LoliCode blocks are clearly distinguishable from enabled ones regardless of the block category base color.

Closes #1223