### PR TITLE
feat: auto-scroll capture list to bottom on new hits

### DIFF
--- a/OpenBullet2.Native/ViewModels/ConfigStackerViewModel.cs
+++ b/OpenBullet2.Native/ViewModels/ConfigStackerViewModel.cs
@@ -291,6 +291,6 @@ public class BlockViewModel(BlockInstance block) : ViewModelBase
         }
     }
 
-    public string BackgroundColor => Disabled ? "#444" : Block.Descriptor.Category.BackgroundColor;
-    public string ForegroundColor => Disabled ? "#FFF" : Block.Descriptor.Category.ForegroundColor;
+    public string BackgroundColor => Disabled ? "#1A1A1A" : Block.Descriptor.Category.BackgroundColor;
+    public string ForegroundColor => Disabled ? "#777777" : Block.Descriptor.Category.ForegroundColor;
 }

--- a/openbullet2-web-client/src/app/main/components/jobs/multi-run-job/multi-run-job.component.html
+++ b/openbullet2-web-client/src/app/main/components/jobs/multi-run-job/multi-run-job.component.html
@@ -507,7 +507,7 @@
                 <div class="named-card-key">
                     Hits
                 </div>
-                <div class="named-card-value hits">
+                <div class="named-card-value hits" #hitsContainer>
                     <ul class="hits-list">
                         <li *ngFor="let hit of filteredHits" class="hit"
                             [class.selected]="isHitSelected(hit)"

--- a/openbullet2-web-client/src/app/main/components/jobs/multi-run-job/multi-run-job.component.ts
+++ b/openbullet2-web-client/src/app/main/components/jobs/multi-run-job/multi-run-job.component.ts
@@ -123,6 +123,8 @@ export class MultiRunJobComponent implements OnInit, OnDestroy {
 
   @ViewChild('hitSoundPlayer') hitSoundPlayer!: ElementRef;
 
+  @ViewChild('hitsContainer') hitsContainer!: ElementRef;
+
   hits: MRJHitDto[] = [];
   filteredHits: MRJHitDto[] = [];
   selectedHits: MRJHitDto[] = [];
@@ -425,6 +427,13 @@ export class MultiRunJobComponent implements OnInit, OnDestroy {
       // Note: if multiple hits are received at the same time, the sound will only play once
       // to avoid spamming the sound
       this.hitSoundPlayer.nativeElement.play();
+    }
+
+    // Auto-scroll to bottom when new hits arrive
+    if (this.hitsContainer) {
+      setTimeout(() => {
+        this.hitsContainer.nativeElement.scrollTop = this.hitsContainer.nativeElement.scrollHeight;
+      });
     }
   }
 


### PR DESCRIPTION
Added #hitsContainer template ref and ViewChild reference in MultiRunJobComponent. After each new hit is added, the hits container scrolls to the bottom automatically.

Closes #1226