### PR TITLE
Fix HTTPS proxy certificate handling across HTTP backends

### DIFF
--- a/RuriLib.Http/Curl/CurlImpersonateHandlerOptions.cs
+++ b/RuriLib.Http/Curl/CurlImpersonateHandlerOptions.cs
@@ -45,7 +45,8 @@ public sealed class CurlImpersonateHandlerOptions
     public bool AutomaticDecompression { get; set; } = true;
 
     /// <summary>
-    /// Whether TLS certificate checks should be bypassed.
+    /// Whether TLS certificate checks for the destination server should be bypassed.
+    /// HTTPS proxy certificates are always accepted.
     /// </summary>
     public bool IgnoreCertificateValidation { get; set; } = true;
 

--- a/RuriLib.Http/Curl/Internal/CurlEasyTransfer.cs
+++ b/RuriLib.Http/Curl/Internal/CurlEasyTransfer.cs
@@ -428,6 +428,15 @@ internal sealed class CurlEasyTransfer : IDisposable
 
         SetStringOption(CurlOption.Proxy, options.ProxyUri.ToString());
 
+        if (options.ProxyUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+        {
+            // HTTPS proxies are typically configured by IP address, which often
+            // does not match the hostname on the proxy certificate. Keep this
+            // independent from destination certificate validation.
+            SetLongOption(CurlOption.ProxySslVerifyPeer, 0);
+            SetLongOption(CurlOption.ProxySslVerifyHost, 0);
+        }
+
         if (options.ProxyCredentials is not null)
         {
             SetStringOption(CurlOption.ProxyUserPwd,

--- a/RuriLib.Http/Curl/Native/CurlOption.cs
+++ b/RuriLib.Http/Curl/Native/CurlOption.cs
@@ -32,6 +32,8 @@ internal enum CurlOption
     SslOptions = 216,
     SslEnableAlpn = 226,
     StreamWeight = 239,
+    ProxySslVerifyPeer = 248,
+    ProxySslVerifyHost = 249,
     SslEcCurves = 10298,
     WriteFunction = 20011,
     HeaderFunction = 20079,

--- a/RuriLib.Tests/Functions/Http/HttpModelTests.cs
+++ b/RuriLib.Tests/Functions/Http/HttpModelTests.cs
@@ -123,6 +123,18 @@ public class HttpModelTests
         Assert.Equal(new Uri("http://127.0.0.1:8080"), handlerOptions.ProxyUri);
     }
 
+    [Theory]
+    [InlineData("münchen-proxy.de", "xn--mnchen-proxy-dlb.de")]
+    [InlineData("PROXY.Example.COM", "proxy.example.com")]
+    [InlineData("[::1]", "::1")]
+    [InlineData("127.0.0.1", "127.0.0.1")]
+    public void GetProxyUri_NormalizesHostForTlsTargetName(string host, string expectedHost)
+    {
+        var proxy = new Proxy(host, 443, ProxyType.Https);
+
+        Assert.Equal(expectedHost, HttpFactory.GetProxyUri(proxy).IdnHost);
+    }
+
     [Fact]
     public async Task CreateMultipartContent_StringWithoutContentType_OmitsHeader()
     {

--- a/RuriLib.Tests/Functions/Http/HttpRequestProxyIntegrationTests.cs
+++ b/RuriLib.Tests/Functions/Http/HttpRequestProxyIntegrationTests.cs
@@ -157,8 +157,11 @@ public class HttpRequestProxyIntegrationTests
         Assert.StartsWith("GET http://example.com/test HTTP/", await proxyServer.WaitForFirstRequestLineAsync());
     }
 
-    [Fact]
-    public async Task HttpRequestStandard_Get_ThroughHttpsProxy_UsesTlsTransport_ForRuriLibHttp()
+    [Theory]
+    [InlineData(HttpLibrary.RuriLibHttp)]
+    [InlineData(HttpLibrary.SystemNet)]
+    public async Task HttpRequestStandard_Get_ThroughHttpsProxy_IgnoresProxyCertificateValidation(
+        HttpLibrary library)
     {
         await using var proxyServer = await FakeHttpsProxyServer.StartAsync();
         var data = NewBotData(new Proxy("127.0.0.1", proxyServer.Port, ProxyType.Https));
@@ -166,9 +169,12 @@ public class HttpRequestProxyIntegrationTests
         {
             Url = "http://example.com/test",
             Method = global::RuriLib.Functions.Http.HttpMethod.GET,
-            HttpLibrary = HttpLibrary.RuriLibHttp,
+            HttpLibrary = library,
             TimeoutMilliseconds = 5000,
-            ReadResponseContent = true
+            ReadResponseContent = true,
+            // This setting only controls the destination server. The proxy in
+            // this test uses an untrusted certificate and must still work.
+            IgnoreCertificateValidation = false
         };
 
         await Methods.HttpRequestStandard(data, options);

--- a/RuriLib.Tests/Functions/Http/HttpTests.cs
+++ b/RuriLib.Tests/Functions/Http/HttpTests.cs
@@ -243,6 +243,30 @@ public class HttpTests
     }
 
     [Fact]
+    public async Task HttpRequestStandard_RuriLibHttpSelfSignedCertificate_RejectsWhenValidationIsEnabled()
+    {
+        await using var httpServer = LocalHttpResponseServer.CreateDelayed(
+            TimeSpan.Zero,
+            Encoding.UTF8.GetBytes("""{"redirected":true}"""),
+            "Content-Type: application/json");
+
+        await using var httpsServer = new LocalHttpsRedirectServer(
+            LocalHttpsRedirectServer.CreateSelfSignedCertificate("localhost"),
+            new Uri($"{httpServer.Uri}final"));
+        var data = NewBotData();
+        var options = new StandardHttpRequestOptions
+        {
+            Url = $"{httpsServer.Uri}start",
+            Method = HttpMethod.GET,
+            HttpLibrary = HttpLibrary.RuriLibHttp,
+            IgnoreCertificateValidation = false
+        };
+
+        await Assert.ThrowsAsync<RuriLib.Proxies.Exceptions.ProxyException>(
+            () => Methods.HttpRequestStandard(data, options));
+    }
+
+    [Fact]
     public async Task HttpRequestStandard_SystemNet_LogsRequestedProtocolWhenVersionFallsBack()
     {
         await using var server = LocalHttpResponseServer.CreateDelayed(

--- a/RuriLib/Functions/Http/HttpFactory.cs
+++ b/RuriLib/Functions/Http/HttpFactory.cs
@@ -149,7 +149,10 @@ public class HttpFactory
                 ReadWriteTimeOut = options.ReadWriteTimeout
             };
 
-            settings.ProxyCertificateValidationCallback = GetCertificateValidationCallback(options);
+            // HTTPS proxies are often supplied by IP address while their
+            // certificate is issued to a hostname. Proxy TLS validation is
+            // therefore bypassed independently from the request block setting.
+            settings.ProxyCertificateValidationCallback = static (_, _, _, _) => true;
             settings.ProxyCertRevocationMode = options.CertRevocationMode;
 
             if (proxy.NeedsAuthentication)
@@ -199,7 +202,7 @@ public class HttpFactory
             };
         }
 
-        return ConfigureHttpMessageHandler(handler, options, cookieContainer);
+        return ConfigureHttpMessageHandler(handler, options, cookieContainer, proxy);
     }
 
     private static WebProxy GetWebProxy(Proxy proxy)
@@ -221,7 +224,7 @@ public class HttpFactory
         return new WebProxy(address, true, null, proxyCredentials);
     }
 
-    private static Uri GetProxyUri(Proxy proxy)
+    internal static Uri GetProxyUri(Proxy proxy)
     {
         var scheme = proxy.Type switch
         {
@@ -236,18 +239,21 @@ public class HttpFactory
         return new Uri($"{scheme}://{proxy.Host}:{proxy.Port}");
     }
 
-    private static HttpMessageHandler ConfigureHttpMessageHandler(HttpMessageHandler handler, HttpOptions options, CookieContainer cookieContainer)
+    private static HttpMessageHandler ConfigureHttpMessageHandler(
+        HttpMessageHandler handler, HttpOptions options, CookieContainer cookieContainer, Proxy? proxy)
     {
         if (options.UseCustomCipherSuites && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             throw new NotSupportedException("Custom cipher suites are not supported on Windows");
         }
 
+        // Match the normalized TLS target name used by SocketsHttpHandler.
+        var proxyHost = proxy?.Type == ProxyType.Https ? GetProxyUri(proxy).IdnHost : null;
         var sslOptions = new SslClientAuthenticationOptions
         {
             CertificateRevocationCheckMode = options.CertRevocationMode,
             EnabledSslProtocols = ToSslProtocols(options.SecurityProtocol),
-            RemoteCertificateValidationCallback = GetCertificateValidationCallback(options),
+            RemoteCertificateValidationCallback = GetCertificateValidationCallback(options, proxyHost),
             CipherSuitesPolicy = options.UseCustomCipherSuites
                 ? new CipherSuitesPolicy(options.CustomCipherSuites)
                 : null
@@ -285,10 +291,26 @@ public class HttpFactory
         return handler;
     }
 
-    private static RemoteCertificateValidationCallback? GetCertificateValidationCallback(HttpOptions options)
-        => options.IgnoreCertificateValidation
-            ? static (_, _, _, _) => true
-            : null;
+    private static RemoteCertificateValidationCallback GetCertificateValidationCallback(
+        HttpOptions options, string? httpsProxyHost = null)
+    {
+        return (sender, _, _, sslPolicyErrors) =>
+        {
+            // SocketsHttpHandler invokes this callback for both TLS layers. The
+            // SslStream target host identifies the HTTPS proxy handshake, whose
+            // certificate is accepted independently from the destination setting.
+            if (httpsProxyHost is not null
+                && sender is SslStream sslStream
+                && string.Equals(sslStream.TargetHostName, httpsProxyHost,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return options.IgnoreCertificateValidation
+                || sslPolicyErrors == SslPolicyErrors.None;
+        };
+    }
 
     /// <summary>
     /// Converts the <paramref name="protocol"/> to an SslProtocols enum. Multiple protocols are not supported and SystemDefault is None.

--- a/RuriLib/Functions/Http/HttpOptions.cs
+++ b/RuriLib/Functions/Http/HttpOptions.cs
@@ -41,7 +41,8 @@ public class HttpOptions
     public SecurityProtocol SecurityProtocol { get; set; } = SecurityProtocol.SystemDefault;
 
     /// <summary>
-    /// Gets or sets whether TLS certificate validity checks should be bypassed.
+    /// Gets or sets whether TLS certificate validity checks for the destination
+    /// server should be bypassed. HTTPS proxy certificates are always accepted.
     /// </summary>
     public bool IgnoreCertificateValidation { get; set; } = true;
 

--- a/RuriLib/Functions/Http/Options/HttpRequestOptions.cs
+++ b/RuriLib/Functions/Http/Options/HttpRequestOptions.cs
@@ -44,7 +44,8 @@ public class HttpRequestOptions
     public SecurityProtocol SecurityProtocol { get; set; } = SecurityProtocol.SystemDefault;
 
     /// <summary>
-    /// Gets or sets whether TLS certificate validity checks should be bypassed.
+    /// Gets or sets whether TLS certificate validity checks for the destination
+    /// server should be bypassed. HTTPS proxy certificates are always accepted.
     /// </summary>
     public bool IgnoreCertificateValidation { get; set; } = true;
 

--- a/RuriLib/Models/Blocks/Custom/HttpRequestBlockDescriptor.cs
+++ b/RuriLib/Models/Blocks/Custom/HttpRequestBlockDescriptor.cs
@@ -63,7 +63,7 @@ public class HttpRequestBlockDescriptor : BlockDescriptor
             },
             ["ignoreCertificateValidation"] = new BoolParameter("ignoreCertificateValidation", true)
             {
-                Description = "Bypass TLS certificate validity checks."
+                Description = "Bypass destination TLS certificate validity checks. HTTPS proxy certificates are always accepted."
             },
             ["useCustomCipherSuites"] = new BoolParameter("useCustomCipherSuites", false)
             {


### PR DESCRIPTION
# Description

HTTPS proxies are often supplied as IP addresses, while their certificates may
be issued to a hostname. This caused the SystemNet backend to reject the proxy TLS
connection with `RemoteCertificateNameMismatch`, even though the same proxy worked
with the native backend.

This change separates HTTPS proxy certificate handling from destination server
certificate handling:

- HTTPS proxy certificates are accepted independently of the request block setting.
- `IgnoreCertificateValidation` now applies only to the destination server.
- The behavior is implemented consistently for RuriLibHttp, SystemNet and
  CurlImpersonate.
- SystemNet uses the normalized proxy TLS target name, including IDN and IPv6
  normalization.
- Option descriptions and inline documentation were updated accordingly.

For CurlImpersonate, `CURLOPT_PROXY_SSL_VERIFYPEER` and
`CURLOPT_PROXY_SSL_VERIFYHOST` are disabled for HTTPS proxies.

Accepting HTTPS proxy certificates independently is intentional. It allows proxies
configured by IP address to work without also disabling certificate validation for
the requested destination.

No additional dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Added and updated tests covering:

- HTTPS proxies with an untrusted certificate using the RuriLibHttp backend.
- HTTPS proxies with an untrusted certificate using the SystemNet backend.
- Proxy certificate acceptance while `IgnoreCertificateValidation` is `false`.
- Rejection of an untrusted destination certificate when
  `IgnoreCertificateValidation` is `false`.
- Proxy host normalization for Unicode domains, case differences, bracketed IPv6
  addresses and IPv4 addresses.

Local test results:

- Focused proxy, destination certificate and host normalization tests: 8 passed.
- RuriLib.Http test suite: 43 passed, 22 skipped.
- RuriLib test suite: 742 passed, 92 skipped.
- One unrelated existing Python cancellation test failed:
  `PythonTests.InvokePython_AsyncCode_PropagatesCancellationIntoPython`.

The affected RuriLib, RuriLib.Http and Web projects build successfully.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes
